### PR TITLE
Escape ${PATH} variable in install-in-azure-cloudshell.sh

### DIFF
--- a/install-in-azure-cloudshell.sh
+++ b/install-in-azure-cloudshell.sh
@@ -16,7 +16,7 @@ then
     curl https://cdn.deislabs.io/porter/latest/install-linux.sh|/bin/bash
     echo "" >> "${HOME}/.bashrc"
     echo "# Updating Path to include porter" >> "${HOME}/.bashrc"
-    echo "export PATH=${HOME}/.porter:${PATH}" >> "${HOME}/.bashrc"
+    echo "export PATH=${HOME}/.porter:\${PATH}" >> "${HOME}/.bashrc"
     echo "# Finish Updating Path to include porter" >> "${HOME}/.bashrc"
     echo "" >> "${HOME}/.bashrc"
     echo ".bashrc updated added porter dir to path"
@@ -36,7 +36,7 @@ then
     chmod +x ${HOME}/.cnab-azure-driver/cnab-azure
     echo "" >> "${HOME}/.bashrc"
     echo "# Updating Path to include cnab-azure-driver" >> "${HOME}/.bashrc"
-    echo "export PATH=${HOME}/.cnab-azure-driver:${PATH}" >> "${HOME}/.bashrc"
+    echo "export PATH=${HOME}/.cnab-azure-driver:\${PATH}" >> "${HOME}/.bashrc"
     echo "# Finish Updating Path to include cnab-azure-driver" >> "${HOME}/.bashrc"
     echo "" >> "${HOME}/.bashrc"
     echo ".bashrc updated added cnab-azure-driver dir to path"


### PR DESCRIPTION
Escaping ${PATH} variable when updating `.bashrc` so that the variable isn't expanded (until `.bashrc` is read).
This means that the PATH won't be stale if other statements are added to `.bashrc` that update the PATH.