### PR TITLE
Feature: allow for operating in alternative clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Some bundles create outputs, the driver captures these in an Azure File Share, t
 | CNAB_AZURE_LOCATION  	|   The location in which to create the ACI Container Group and Resource Group	|
 | CNAB_AZURE_NAME  	|   The name of the ACI instance to create - if not specified a name will be generated	|
 | CNAB_AZURE_DELETE_RESOURCES  	|  Set to false so as not to delete the RG and ACI container group created, default is true - useful for debugging - only deletes RG if it was created by the driver 	|
+| CNAB_AZURE_CLI_ARM_ENDPOINT        | The URL for the Azure Resource Manager when using from the CLI. This defaults to 'https://management.azure.com/ |
+| CNAB_AZURE_MSI_AUDIENCE        | The 'audience' to include in the Cloud Shell MSI token request. This defaults to 'https://management.azure.com/' but can be changed if needed for clouds other than Azure public. |
 | CNAB_AZURE_MSI_TYPE  	|   This can be set to either `user` or `system` This value is presented to the invocation image container as `AZURE_MSI_TYPE`|
 | CNAB_AZURE_SYSTEM_MSI_ROLE  	|  If `CNAB_AZURE_SYSTEM_MSI_ROLE` is set to `system` this defines the role to be assigned to System MSI User, if this is null or empty then the role defaults to `Contributor`	|
 | CNAB_AZURE_SYSTEM_MSI_SCOPE  	|  If `CNAB_AZURE_SYSTEM_MSI_ROLE` is set to `system` this defines the scope to apply the role to System MSI User - if this is null or empty then the scope will be Resource Group that the ACI Instance is being created |

--- a/pkg/azure/login_info.go
+++ b/pkg/azure/login_info.go
@@ -124,6 +124,12 @@ func GetCloudShellToken() (*adal.Token, error) {
 		return nil, errors.New("MSI_ENDPOINT environment variable not set")
 	}
 
+	MSIAudience := os.Getenv("CNAB_AZURE_MSI_AUDIENCE")
+	if len(MSIAudience) == 0 {
+		MSIAudience = "https://management.azure.com/"
+	}
+	log.Debug("CloudShell MSI Audience: ", MSIAudience)
+
 	timeout := time.Duration(1 * time.Second)
 	client := http.Client{
 		Timeout: timeout,
@@ -136,7 +142,7 @@ func GetCloudShellToken() (*adal.Token, error) {
 	req.Header.Set("Metadata", "true")
 	query := req.URL.Query()
 	query.Add("api-version", "2018-02-01")
-	query.Add("resource", "https://management.azure.com/")
+	query.Add("resource", MSIAudience)
 	req.URL.RawQuery = query.Encode()
 	log.Debug("Cloud Shell Token URI: ", req.RequestURI)
 	resp, err := client.Do(req)

--- a/pkg/driver/aci-driver.go
+++ b/pkg/driver/aci-driver.go
@@ -1208,7 +1208,14 @@ func (d *aciDriver) createCredentialEnvVars(env []containerinstance.EnvironmentV
 
 	if d.loginInfo.LoginType == az.CLI {
 		log.Debug("Propagating OAuth Token from cli")
-		t, err := cli.GetTokenFromCLI("https://management.azure.com/")
+
+		ARMEndpoint := os.Getenv("CNAB_AZURE_CLI_ARM_ENDPOINT")
+		if len(ARMEndpoint) == 0 {
+			ARMEndpoint = "https://management.azure.com/"
+		}
+		log.Debug("CLI ARM Endpoint: ", ARMEndpoint)
+
+		t, err := cli.GetTokenFromCLI(ARMEndpoint)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes #34 

When operating outside of the public Azure cloud (i.e. in healthcare, finance, government, etc.) the default use of `https:\\management.azure.com` for the Azure Resource Manager and OAuth2 audience is problematic. This request implements a solution by introducing two more environment variables:

|  Environment Variable 	| Description  	|
|---	|---	|
| CNAB_AZURE_CLI_ARM_ENDPOINT        | The URL for the Azure Resource Manager when using from the CLI. This defaults to 'https://management.azure.com/' |
| CNAB_AZURE_MSI_AUDIENCE        | The 'audience' to include in the Cloud Shell MSI token request. This defaults to 'https://management.azure.com/' but can be changed if needed for clouds other than Azure public. |

Also, it appears possible to lookup the ARM Endpoint from the CLI. To keep this request as simple as possible, that step was not added.